### PR TITLE
Add `getArgumentsNumber`, `getArgumentType` and `getReturnType` to ICallingConvention.

### DIFF
--- a/include/dynohook/convention.h
+++ b/include/dynohook/convention.h
@@ -76,6 +76,24 @@ namespace dyno {
 		virtual void* getArgumentPtr(size_t index, const Registers& registers) = 0;
 
 		/**
+		 * @brief Returns the number of arguments.
+		 * @return
+		 */
+		size_t getArgumentsNumber() const;
+
+		/**
+		 * @brief Returns the type of an argument at the given index.
+		 * @return
+		 */
+		DataType getArgumentType(size_t index) const;
+
+		/**
+		 * @brief Returns the type of return value.
+		 * @return
+		 */
+		DataType getReturnType() const;
+
+		/**
 		 * @brief
 		 * @param index The index of the argument.
 		 * @param registers A snapshot of all saved registers.

--- a/include/dynohook/ihook.h
+++ b/include/dynohook/ihook.h
@@ -68,6 +68,18 @@ namespace dyno {
 		 */
 		virtual bool areCallbacksRegistered() const = 0;
 
+		size_t getArgumentsNumber() {
+		    return getCallingConvention().getArgumentsNumber();
+	    }
+
+		DataType getArgumentType(size_t index) {
+		    return getCallingConvention().getArgumentType(index);
+	    }
+
+		DataType getReturnType() {
+		    return getCallingConvention().getReturnType();
+	    }
+
 		template<class T>
 		T getArgument(size_t index) {
 			return *(T*) getCallingConvention().getArgumentPtr(index, getRegisters());

--- a/src/convention.cpp
+++ b/src/convention.cpp
@@ -30,6 +30,21 @@ void ICallingConvention::init() {
 		m_return.size = static_cast<uint16_t>(getDataTypeSize(m_return.type, m_alignment));
 }
 
+size_t ICallingConvention::getArgumentsNumber() const {
+	return m_arguments.size();
+}
+
+DataType ICallingConvention::getArgumentType(size_t index) const{
+	if (index >= m_arguments.size())
+		return DataType::Void;
+
+	return m_arguments[index].type;
+}
+
+DataType ICallingConvention::getReturnType() const{
+	return m_return.type;
+}
+
 void ICallingConvention::saveReturnValue(const Registers& registers) {
 	std::unique_ptr<uint8_t[]> savedReturnValue = std::make_unique<uint8_t[]>(m_return.size);
 	std::memcpy(savedReturnValue.get(), getReturnPtr(registers), m_return.size);


### PR DESCRIPTION
## Why?
While I was developing an application with this library, I identified the need for additional functionality. Without these enhancements, the application must externally track the types of arguments and return values, even though this information is already encapsulated within the ICallingConvention object.

## What?
To address this, I propose the following functions:
`getArgumentsNumber`: Retrieves the total number of arguments in the hooked API.
`getArgumentType`: Returns the type of the argument at the specified index.
`getReturnType`: Returns the type of the return value.