### PR TITLE
Change CallbackHandler to std::function instead of a function pointer.

### DIFF
--- a/include/dynohook/ihook.h
+++ b/include/dynohook/ihook.h
@@ -28,7 +28,8 @@ namespace dyno {
 	};
 
 	class IHook;
-	using CallbackHandler = ReturnAction (*)(CallbackType, IHook&);
+	using CallbackHandlerFunPtr = ReturnAction (*)(CallbackType, IHook&);
+	using CallbackHandler = std::function<ReturnAction(CallbackType, IHook&)>;
 	using ConvFunc = std::function<ICallingConvention*()>;
 
 	/**


### PR DESCRIPTION
## Why?
In my use case with this library, I needed to pass a lambda to addCallback function to encapsulate a different callback. For example:

```
class HookedWinAPI {
    using HookedAPIHandler = std::function<ReturnAction(CallbackType, HookedWinAPI&)>;
    x64Detour m_hook;
    
    void add_callback(CallbackType callback_type, HookedAPIHandler callback_handler) {
        m_hook->addCallback(callback_type, [this, callback_handler](CallbackType type, IHook& hook) -> ReturnAction {
            return callback_handler(type, *this);
        });
    }
};
```
## What?
The changes introduced in this PR increase the library’s flexibility by allowing the use of lambdas (and other callable objects) as callbacks, while maintaining compatibility with traditional function pointers. This added flexibility is particularly useful when callbacks need to access member functions or state from the context in which they are registered.

## Pitfall
One limitation of this approach is that callbacks that are not function pointers (e.g., lambdas or std::function objects) are not directly comparable. This affects the ability to:

* Check for existing callbacks in addCallback.
* Remove callbacks using removeCallback.
* Verify callback registration with isCallbackRegistered.

This is because objects like lambdas lack a consistent address or identity that can be compared. Users should be mindful of this limitation when using non-function-pointer callbacks. The library will still give useful warnings in that case.